### PR TITLE
feat: Add initial UI for Apps & Integrations page

### DIFF
--- a/src/components/Admin/AppsAndIntegrations.tsx
+++ b/src/components/Admin/AppsAndIntegrations.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Calendar, CreditCard, Video } from 'lucide-react';
+
+const integrations = [
+    {
+        name: 'Google Calendar',
+        description: 'Sync your calendar to manage bookings and availability.',
+        icon: <Calendar className="h-8 w-8" />,
+        connected: false,
+    },
+    {
+        name: 'Stripe',
+        description: 'Connect your Stripe account to process payments for bookings.',
+        icon: <CreditCard className="h-8 w-8" />,
+        connected: false,
+    },
+    {
+        name: 'Google Meet',
+        description: 'Automatically create Google Meet links for your bookings.',
+        icon: <Video className="h-8 w-8" />,
+        connected: false,
+    },
+];
+
+const AppsAndIntegrations = () => {
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold mb-6">Apps & Integrations</h1>
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {integrations.map((integration) => (
+                    <Card key={integration.name}>
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <div className="flex items-center gap-4">
+                                {integration.icon}
+                                <CardTitle>{integration.name}</CardTitle>
+                            </div>
+                            <Button variant={integration.connected ? 'secondary' : 'default'}>
+                                {integration.connected ? 'Manage' : 'Connect'}
+                            </Button>
+                        </CardHeader>
+                        <CardContent>
+                            <CardDescription>{integration.description}</CardDescription>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default AppsAndIntegrations;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import {
     LayoutDashboard, Users, GraduationCap, CalendarDays, BookOpen,
     Settings, LogOut, Home, MessageSquare, Plus, DollarSign, Crown,
-    Clock, Bell, User, Menu, X
+    Clock, Bell, User, Menu, X, Puzzle
 } from "lucide-react";
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
@@ -39,6 +39,7 @@ const navLinks = {
         { label: "Bookings", href: "/admin/bookings", icon: CalendarDays },
         { label: "Subjects", href: "/admin/subjects", icon: BookOpen },
         { label: "Admins", href: "/admin/admins", icon: Crown },
+        { label: "Apps & Integrations", href: "/admin/apps-and-integrations", icon: Puzzle },
         { label: "Settings", href: "/admin/settings", icon: Settings },
         { label: "Profile", href: "/admin/profile", icon: User },
         { label: "Demo Requests", href: "/admin/demo-requests", icon: Bell },

--- a/src/pages/admin/apps-and-integrations.tsx
+++ b/src/pages/admin/apps-and-integrations.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import AdminLayout from './_layout';
+import AppsAndIntegrations from '@/components/Admin/AppsAndIntegrations';
+
+export default function AppsAndIntegrationsPage() {
+    return (
+        <AdminLayout>
+            <AppsAndIntegrations />
+        </AdminLayout>
+    );
+}


### PR DESCRIPTION
This commit introduces the initial user interface for the 'Apps & Integrations' page in the admin dashboard.

- Adds a new link to the admin sidebar for 'Apps & Integrations'.
- Creates a new page at `/admin/apps-and-integrations`.
- Implements a UI with cards for Google Calendar, Stripe, and Google Meet integrations.

This is the first step in a larger feature. The backend integration logic will be implemented in subsequent commits.