### PR TITLE
feat: Add ability to read Google Calendar events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# mock db
+db.json
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "firebase": "^12.2.1",
         "firebase-admin": "^13.5.0",
         "framer-motion": "^12.23.12",
+        "google-auth-library": "^10.3.0",
+        "googleapis": "^160.0.0",
         "lucide-react": "^0.543.0",
         "next": "15.5.2",
         "nodemailer": "^7.0.6",
@@ -1621,6 +1623,63 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/uuid": {
@@ -5342,6 +5401,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -5413,7 +5473,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -5706,6 +5765,15 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6640,6 +6708,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6748,6 +6839,59 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/firebase-admin/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -6816,6 +6960,18 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/framer-motion": {
@@ -6915,16 +7071,49 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/get-caller-file": {
@@ -7048,19 +7237,53 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.3.0.tgz",
+      "integrity": "sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/google-gax": {
@@ -7117,6 +7340,63 @@
         "node": ">=6"
       }
     },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/google-gax/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -7131,11 +7411,73 @@
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "160.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-160.0.0.tgz",
+      "integrity": "sha512-lAGFQVSeYvWKCxeCQKo20xWFFDgnWuJYbLn92IgLrT4UTYVOGdrZ9XTqgWJf316isE9KdfuDY5X8Tu4ZrXSFig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.0.tgz",
+      "integrity": "sha512-66if47It7y+Sab3HMkwEXx1kCq9qUC9px8ZXoj1CMrmLmUw81GpbnsNlXnlyZyGbGPGcj+tDD9XsZ23m7GLaJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gopd": {
@@ -7162,15 +7504,48 @@
       "dev": true
     },
     "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/has-bigints": {
@@ -7860,6 +8235,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -7953,6 +8329,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7979,6 +8356,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -8634,6 +9012,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -8691,7 +9089,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9023,6 +9420,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -9602,7 +10014,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -9621,7 +10032,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -9637,7 +10047,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -9655,7 +10064,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -10320,6 +10728,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -10406,6 +10820,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "firebase": "^12.2.1",
     "firebase-admin": "^13.5.0",
     "framer-motion": "^12.23.12",
+    "google-auth-library": "^10.3.0",
+    "googleapis": "^160.0.0",
     "lucide-react": "^0.543.0",
     "next": "15.5.2",
     "nodemailer": "^7.0.6",

--- a/src/components/Admin/AppsAndIntegrations.tsx
+++ b/src/components/Admin/AppsAndIntegrations.tsx
@@ -1,50 +1,135 @@
-import React from 'react';
+"use client"
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Calendar, CreditCard, Video } from 'lucide-react';
+
+interface CalendarEvent {
+    summary: string;
+    start: {
+        dateTime: string;
+    };
+    end: {
+        dateTime: string;
+    };
+}
 
 const integrations = [
     {
         name: 'Google Calendar',
         description: 'Sync your calendar to manage bookings and availability.',
         icon: <Calendar className="h-8 w-8" />,
-        connected: false,
+        statusUrl: '/api/admin/integrations/google-calendar/status',
+        connectUrl: '/api/admin/integrations/google-calendar',
+        eventsUrl: '/api/admin/integrations/google-calendar/events',
     },
     {
         name: 'Stripe',
         description: 'Connect your Stripe account to process payments for bookings.',
         icon: <CreditCard className="h-8 w-8" />,
-        connected: false,
+        statusUrl: '#',
+        connectUrl: '#',
     },
     {
         name: 'Google Meet',
         description: 'Automatically create Google Meet links for your bookings.',
         icon: <Video className="h-8 w-8" />,
-        connected: false,
+        statusUrl: '#',
+        connectUrl: '#',
     },
 ];
 
 const AppsAndIntegrations = () => {
+    const [connectionStatus, setConnectionStatus] = useState<Record<string, boolean>>({});
+    const [events, setEvents] = useState<CalendarEvent[]>([]);
+    const [isLoadingEvents, setIsLoadingEvents] = useState(false);
+
+    useEffect(() => {
+        const fetchStatus = async () => {
+            const status: Record<string, boolean> = {};
+            for (const integration of integrations) {
+                if (integration.statusUrl !== '#') {
+                    try {
+                        const res = await fetch(integration.statusUrl);
+                        const data = await res.json();
+                        status[integration.name] = data.connected;
+                    } catch (error) {
+                        console.error(`Failed to fetch status for ${integration.name}`, error);
+                        status[integration.name] = false;
+                    }
+                }
+            }
+            setConnectionStatus(status);
+        };
+        fetchStatus();
+    }, []);
+
+    const handleFetchEvents = async (url: string) => {
+        if (!url || url === '#') return;
+        setIsLoadingEvents(true);
+        try {
+            const res = await fetch(url);
+            const data = await res.json();
+            setEvents(data);
+        } catch (error) {
+            console.error('Failed to fetch events', error);
+        }
+        setIsLoadingEvents(false);
+    };
+
     return (
         <div className="p-6">
             <h1 className="text-3xl font-bold mb-6">Apps & Integrations</h1>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {integrations.map((integration) => (
-                    <Card key={integration.name}>
-                        <CardHeader className="flex flex-row items-center justify-between">
-                            <div className="flex items-center gap-4">
-                                {integration.icon}
-                                <CardTitle>{integration.name}</CardTitle>
-                            </div>
-                            <Button variant={integration.connected ? 'secondary' : 'default'}>
-                                {integration.connected ? 'Manage' : 'Connect'}
-                            </Button>
-                        </CardHeader>
-                        <CardContent>
-                            <CardDescription>{integration.description}</CardDescription>
-                        </CardContent>
-                    </Card>
-                ))}
+                {integrations.map((integration) => {
+                    const isConnected = connectionStatus[integration.name];
+                    return (
+                        <Card key={integration.name}>
+                            <CardHeader className="flex flex-row items-center justify-between">
+                                <div className="flex items-center gap-4">
+                                    {integration.icon}
+                                    <CardTitle>{integration.name}</CardTitle>
+                                </div>
+                                {isConnected ? (
+                                    <Dialog>
+                                        <DialogTrigger asChild>
+                                            <Button variant="secondary" onClick={() => handleFetchEvents(integration.eventsUrl || '#')}>
+                                                Manage
+                                            </Button>
+                                        </DialogTrigger>
+                                        <DialogContent>
+                                            <DialogHeader>
+                                                <DialogTitle>{integration.name} Events</DialogTitle>
+                                            </DialogHeader>
+                                            {isLoadingEvents ? (
+                                                <p>Loading events...</p>
+                                            ) : (
+                                                <ul>
+                                                    {events.map((event, index) => (
+                                                        <li key={index} className="mb-2">
+                                                            <strong>{event.summary}</strong>
+                                                            <p className="text-sm text-gray-500">
+                                                                {new Date(event.start.dateTime).toLocaleString()} - {new Date(event.end.dateTime).toLocaleString()}
+                                                            </p>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            )}
+                                        </DialogContent>
+                                    </Dialog>
+                                ) : (
+                                    <Button asChild>
+                                        <a href={integration.connectUrl}>Connect</a>
+                                    </Button>
+                                )}
+                            </CardHeader>
+                            <CardContent>
+                                <CardDescription>{integration.description}</CardDescription>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
             </div>
         </div>
     );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,39 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Credentials } from 'google-auth-library';
+
+const dbPath = path.resolve(process.cwd(), 'db.json');
+
+interface DbData {
+    googleCalendar: {
+        tokens: Credentials | null;
+    };
+}
+
+async function readDb(): Promise<DbData> {
+    try {
+        const data = await fs.readFile(dbPath, 'utf-8');
+        return JSON.parse(data);
+    } catch (error) {
+        // If the file doesn't exist, return a default structure
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { googleCalendar: { tokens: null } };
+        }
+        throw error;
+    }
+}
+
+async function writeDb(data: DbData): Promise<void> {
+    await fs.writeFile(dbPath, JSON.stringify(data, null, 2));
+}
+
+export async function saveTokens(tokens: Credentials): Promise<void> {
+    const db = await readDb();
+    db.googleCalendar.tokens = tokens;
+    await writeDb(db);
+}
+
+export async function getTokens(): Promise<Credentials | null> {
+    const db = await readDb();
+    return db.googleCalendar.tokens;
+}

--- a/src/pages/api/admin/integrations/google-calendar/callback.ts
+++ b/src/pages/api/admin/integrations/google-calendar/callback.ts
@@ -1,0 +1,33 @@
+import { OAuth2Client } from 'google-auth-library';
+import { google } from 'googleapis';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { saveTokens } from '@/lib/db';
+
+const oAuth2Client = new OAuth2Client(
+    process.env.GOOGLE_CLIENT_ID || 'YOUR_DUMMY_CLIENT_ID',
+    process.env.GOOGLE_CLIENT_SECRET || 'YOUR_DUMMY_CLIENT_SECRET',
+    process.env.GOOGLE_REDIRECT_URI || 'http://localhost:3000/api/admin/integrations/google-calendar/callback'
+);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const code = req.query.code as string;
+
+    try {
+        const { tokens } = await oAuth2Client.getToken(code);
+        oAuth2Client.setCredentials(tokens);
+
+        await saveTokens(tokens);
+        console.log('Tokens saved successfully.');
+
+        // Example API call to Google Calendar
+        const calendar = google.calendar({ version: 'v3', auth: oAuth2Client });
+        const calendarList = await calendar.calendarList.list();
+        console.log('User calendars:', calendarList.data.items);
+
+        // Redirect back to the integrations page.
+        res.redirect('/admin/apps-and-integrations');
+    } catch (error) {
+        console.error('Error retrieving access token or fetching calendar data', error);
+        res.redirect('/admin/apps-and-integrations?error=true');
+    }
+}

--- a/src/pages/api/admin/integrations/google-calendar/events.ts
+++ b/src/pages/api/admin/integrations/google-calendar/events.ts
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getTokens } from '@/lib/db';
+import { OAuth2Client } from 'google-auth-library';
+import { google } from 'googleapis';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const tokens = await getTokens();
+        if (!tokens) {
+            return res.status(401).json({ error: 'Not connected to Google Calendar' });
+        }
+
+        const oAuth2Client = new OAuth2Client(
+            process.env.GOOGLE_CLIENT_ID || 'YOUR_DUMMY_CLIENT_ID',
+            process.env.GOOGLE_CLIENT_SECRET || 'YOUR_DUMMY_CLIENT_SECRET'
+        );
+        oAuth2Client.setCredentials(tokens);
+
+        const calendar = google.calendar({ version: 'v3', auth: oAuth2Client });
+
+        const now = new Date();
+        const sevenDaysFromNow = new Date();
+        sevenDaysFromNow.setDate(now.getDate() + 7);
+
+        const response = await calendar.events.list({
+            calendarId: 'primary',
+            timeMin: now.toISOString(),
+            timeMax: sevenDaysFromNow.toISOString(),
+            maxResults: 10,
+            singleEvents: true,
+            orderBy: 'startTime',
+        });
+
+        res.status(200).json(response.data.items);
+    } catch (error) {
+        console.error('Error fetching calendar events', error);
+        res.status(500).json({ error: 'Failed to fetch calendar events' });
+    }
+}

--- a/src/pages/api/admin/integrations/google-calendar/index.ts
+++ b/src/pages/api/admin/integrations/google-calendar/index.ts
@@ -1,0 +1,16 @@
+import { OAuth2Client } from 'google-auth-library';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const oAuth2Client = new OAuth2Client(
+    process.env.GOOGLE_CLIENT_ID || 'YOUR_DUMMY_CLIENT_ID',
+    process.env.GOOGLE_CLIENT_SECRET || 'YOUR_DUMMY_CLIENT_SECRET',
+    process.env.GOOGLE_REDIRECT_URI || 'http://localhost:3000/api/admin/integrations/google-calendar/callback'
+);
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+    const authorizeUrl = oAuth2Client.generateAuthUrl({
+        access_type: 'offline',
+        scope: 'https://www.googleapis.com/auth/calendar',
+    });
+    res.redirect(authorizeUrl);
+}

--- a/src/pages/api/admin/integrations/google-calendar/status.ts
+++ b/src/pages/api/admin/integrations/google-calendar/status.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getTokens } from '@/lib/db';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const tokens = await getTokens();
+        if (tokens) {
+            res.status(200).json({ connected: true });
+        } else {
+            res.status(200).json({ connected: false });
+        }
+    } catch (error) {
+        console.error('Error reading tokens from db', error);
+        res.status(500).json({ error: 'Failed to get connection status' });
+    }
+}


### PR DESCRIPTION
This commit enhances the Google Calendar integration by adding the functionality to read and display events from the connected account.

- Creates a new API route (`/api/admin/integrations/google-calendar/events`) that fetches the next 7 days of events from the user's primary calendar.
- Updates the 'Apps & Integrations' UI: when Google Calendar is connected, a 'Manage' button is shown.
- Clicking 'Manage' opens a dialog that displays a list of upcoming calendar events.
- The UI shows a loading state while events are being fetched.