### PR TITLE
feat: Integrate Firebase for Google Calendar token storage

### DIFF
--- a/src/pages/api/admin/integrations/google-calendar/callback.ts
+++ b/src/pages/api/admin/integrations/google-calendar/callback.ts
@@ -10,14 +10,23 @@ const oAuth2Client = new OAuth2Client(
 );
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-    const code = req.query.code as string;
+    const { code, state } = req.query;
+
+    if (typeof state !== 'string' || !state) {
+        return res.status(400).json({ error: 'Missing state parameter (userId)' });
+    }
+    const userId = state;
+
+    if (typeof code !== 'string' || !code) {
+        return res.status(400).json({ error: 'Missing code parameter' });
+    }
 
     try {
         const { tokens } = await oAuth2Client.getToken(code);
         oAuth2Client.setCredentials(tokens);
 
-        await saveTokens(tokens);
-        console.log('Tokens saved successfully.');
+        await saveTokens(userId, tokens);
+        console.log(`Tokens saved successfully for user ${userId}.`);
 
         // Example API call to Google Calendar
         const calendar = google.calendar({ version: 'v3', auth: oAuth2Client });

--- a/src/pages/api/admin/integrations/google-calendar/events.ts
+++ b/src/pages/api/admin/integrations/google-calendar/events.ts
@@ -2,10 +2,18 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getTokens } from '@/lib/db';
 import { OAuth2Client } from 'google-auth-library';
 import { google } from 'googleapis';
+import { adminAuth } from '@/lib/firebaseAdmin';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
-        const tokens = await getTokens();
+        const token = req.headers.authorization?.split(" ")[1];
+        if (!token) {
+            return res.status(401).json({ error: "Unauthorized" });
+        }
+        const decodedToken = await adminAuth.verifyIdToken(token);
+        const uid = decodedToken.uid;
+
+        const tokens = await getTokens(uid);
         if (!tokens) {
             return res.status(401).json({ error: 'Not connected to Google Calendar' });
         }

--- a/src/pages/api/admin/integrations/google-calendar/index.ts
+++ b/src/pages/api/admin/integrations/google-calendar/index.ts
@@ -1,5 +1,6 @@
 import { OAuth2Client } from 'google-auth-library';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { adminAuth } from '@/lib/firebaseAdmin';
 
 const oAuth2Client = new OAuth2Client(
     process.env.GOOGLE_CLIENT_ID || 'YOUR_DUMMY_CLIENT_ID',
@@ -7,10 +8,26 @@ const oAuth2Client = new OAuth2Client(
     process.env.GOOGLE_REDIRECT_URI || 'http://localhost:3000/api/admin/integrations/google-calendar/callback'
 );
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-    const authorizeUrl = oAuth2Client.generateAuthUrl({
-        access_type: 'offline',
-        scope: 'https://www.googleapis.com/auth/calendar',
-    });
-    res.redirect(authorizeUrl);
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const { token } = req.query;
+        if (typeof token !== 'string' || !token) {
+            return res.status(401).json({ error: "Unauthorized: Missing token" });
+        }
+
+        const decodedToken = await adminAuth.verifyIdToken(token);
+        const uid = decodedToken.uid;
+
+        const authorizeUrl = oAuth2Client.generateAuthUrl({
+            access_type: 'offline',
+            scope: 'https://www.googleapis.com/auth/calendar',
+            // Pass the user's UID in the state parameter to identify them in the callback
+            state: uid,
+        });
+
+        res.redirect(authorizeUrl);
+    } catch (error) {
+        console.error("Error generating auth URL", error);
+        res.status(500).json({ error: "Failed to initiate Google authentication" });
+    }
 }

--- a/src/pages/api/admin/integrations/google-calendar/status.ts
+++ b/src/pages/api/admin/integrations/google-calendar/status.ts
@@ -1,16 +1,22 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getTokens } from '@/lib/db';
+import { adminAuth } from '@/lib/firebaseAdmin';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
-        const tokens = await getTokens();
-        if (tokens) {
-            res.status(200).json({ connected: true });
-        } else {
-            res.status(200).json({ connected: false });
+        const token = req.headers.authorization?.split(" ")[1];
+        if (!token) {
+            return res.status(401).json({ error: "Unauthorized" });
         }
+        const decodedToken = await adminAuth.verifyIdToken(token);
+        const uid = decodedToken.uid;
+
+        const tokens = await getTokens(uid);
+
+        res.status(200).json({ connected: !!tokens });
+
     } catch (error) {
-        console.error('Error reading tokens from db', error);
+        console.error('Error getting connection status', error);
         res.status(500).json({ error: 'Failed to get connection status' });
     }
 }


### PR DESCRIPTION
This commit refactors the Google Calendar integration to use Firestore for storing and retrieving OAuth tokens, replacing the temporary file-based storage.

- The database logic in `src/lib/db.ts` is now implemented with the Firebase Admin SDK.
- Tokens are stored in a user-specific subcollection (`/users/{userId}/integrations/googleCalendar`) in Firestore.
- All related API routes (`/api/admin/integrations/google-calendar/*`) are now authenticated, verifying the user's Firebase JWT to ensure security.
- The OAuth flow is updated to securely handle user identity, passing the UID through the `state` parameter.
- The frontend now uses an authenticated axios instance for all integration-related API calls.