### PR TITLE
fix: Add userinfo scopes to Google OAuth request

### DIFF
--- a/src/pages/api/admin/integrations/google-calendar/index.ts
+++ b/src/pages/api/admin/integrations/google-calendar/index.ts
@@ -20,7 +20,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         const authorizeUrl = oAuth2Client.generateAuthUrl({
             access_type: 'offline',
-            scope: 'https://www.googleapis.com/auth/calendar',
+            scope: [
+                'https://www.googleapis.com/auth/calendar',
+                'https://www.googleapis.com/auth/userinfo.email',
+                'https://www.googleapis.com/auth/userinfo.profile',
+            ],
             // Pass the user's UID in the state parameter to identify them in the callback
             state: uid,
         });


### PR DESCRIPTION
This commit fixes a bug where the application would fail to retrieve the user's Google account information after a successful OAuth connection. The root cause was missing permissions (scopes) in the initial authentication request.

- The `scope` in the `generateAuthUrl` call now includes `userinfo.email` and `userinfo.profile`.
- This ensures the application has the necessary permissions to access the user's basic profile information, resolving the 401 error in the callback.