### PR TITLE
fix: Correct disconnect URLs for integrations

### DIFF
--- a/src/components/Admin/AppsAndIntegrations.tsx
+++ b/src/components/Admin/AppsAndIntegrations.tsx
@@ -40,7 +40,7 @@ const integrations = [
         icon: <CreditCard className="h-8 w-8" />,
         statusUrl: '/admin/integrations/stripe/status',
         connectUrl: '/api/admin/integrations/stripe/connect',
-        disconnectUrl: '/api/admin/integrations/stripe/disconnect',
+        disconnectUrl: '/admin/integrations/stripe/disconnect',
     },
     {
         name: 'Google Meet',
@@ -55,7 +55,7 @@ const integrations = [
         icon: <CreditCard className="h-8 w-8" />,
         statusUrl: '/admin/integrations/razorpay/status',
         connectUrl: '#', // Handled by dialog
-        disconnectUrl: '/api/admin/integrations/razorpay/disconnect',
+        disconnectUrl: '/admin/integrations/razorpay/disconnect',
     },
 ];
 


### PR DESCRIPTION
This commit fixes a bug where the 'Disconnect' buttons for the Stripe and Razorpay integrations were pointing to incorrect API endpoints.

- The `disconnectUrl` paths in the `integrations` array in `AppsAndIntegrations.tsx` have been corrected to remove the `/api` prefix.
- This ensures the frontend calls work correctly with the `axios` instance's `baseURL`, which automatically prepends `/api`.